### PR TITLE
Add ability to load config from lirc remote file

### DIFF
--- a/irsling.cpp
+++ b/irsling.cpp
@@ -1,0 +1,261 @@
+
+#include <string>
+#include <vector>
+#include <map>
+#include <fstream>
+#include <iostream>
+#include <getopt.h>
+#include <unistd.h>
+#include "irslinger.h"
+
+std::map<std::string,int> config;
+std::map<std::string,std::string> codes;
+bool in_codes = false;
+
+const char * delimiters = " \t\r\n";
+int handle_line(const std::string & line)
+{
+	size_t start = line.find_first_not_of(delimiters);
+	size_t end = start;
+	std::vector<std::string> tokens;
+
+	while (start != std::string::npos){
+		// Find next occurence of delimiter
+		end = line.find_first_of(delimiters, start);
+		// Push back the token found into vector
+		tokens.push_back(line.substr(start, end-start));
+		// Skip all occurences of the delimiter to find new start
+		start = line.find_first_not_of(delimiters, end);
+	}
+	// bale if no tokens
+	if (tokens.empty()) { return 0; }
+	if (tokens[0].at(0) == '#') { return 0; }
+	// find number of valid tokens
+	size_t i=1;
+	size_t maxtoken = tokens.size()-1;
+	while (i < tokens.size()) {
+		if (tokens[i].at(0) == '#') {
+			maxtoken = i-1;
+			break;
+		}
+		++i;
+	}
+	// all lines in >=2 tokens
+	if (maxtoken == 0) {
+		std::cerr << "Invalid line: "<<line<<std::endl;
+		return -1;
+	}
+
+	char xx[50];
+	// special case config
+	if (tokens[0] == "begin" && tokens[1] == "remote") {
+		// ignore
+		return 0;
+	}
+	if (tokens[0] == "end" && tokens[1] == "remote") {
+		// ignore
+		return 0;
+	}
+	if (tokens[0] == "name") {
+		// ignore
+		return 0;
+	}
+	if (tokens[0] == "flags") {
+		// ignore for now, TODO need to check for rc5 etc.
+		return 0;
+	}
+	try
+	{
+		if (tokens[0] == "header") {
+			if (maxtoken == 1) {
+				std::cerr << "Missing off time in line: "<<line<<std::endl;
+				return -1;
+			}
+			config["header.on"] = std::stoi(tokens[1]);
+			config["header.off"] = std::stoi(tokens[2]);
+			return 0;
+		}
+		if (tokens[0] == "one") {
+			if (maxtoken == 1) {
+				std::cerr << "Missing off time in line: "<<line<<std::endl;
+				return -1;
+			}
+			config["one.on"] = std::stoi(tokens[1]);
+			config["one.off"] = std::stoi(tokens[2]);
+			return 0;
+		}
+		if (tokens[0] == "zero") {
+			if (maxtoken == 1) {
+				std::cerr << "Missing off time in line: "<<line<<std::endl;
+				return -1;
+			}
+			config["zero.on"] = std::stoi(tokens[1]);
+			config["zero.off"] = std::stoi(tokens[2]);
+			return 0;
+		}
+		if (tokens[0] == "repeat") {
+			if (maxtoken == 1) {
+				std::cerr << "Missing off time in line: "<<line<<std::endl;
+				return -1;
+			}
+			config["repeat.on"] = std::stoi(tokens[1]);
+			config["repeat.off"] = std::stoi(tokens[2]);
+			return 0;
+		}
+		if (tokens[0] == "begin" && tokens[1] == "codes") {
+			in_codes = true;
+			return 0;
+		}
+		if (tokens[0] == "end" && tokens[1] == "codes") {
+			in_codes = false;
+			return 0;
+		}
+		if (in_codes) {
+			// TODO what if bits is not multiple of 4?
+			snprintf(xx,sizeof(xx),"%0*x",(3+config["bits"])/4,std::stoi(tokens[1],nullptr,0));
+			codes[tokens[0]] = std::string(xx);
+			return 0;
+		}
+
+		// just save the numeric value
+		config[tokens[0]] = std::stoi(tokens[1],nullptr,0);
+	}
+	catch (...)
+	{
+		std::cerr << "Bad integer in line: "<<line<<std::endl;
+		return -1;
+	}
+	return 0;
+}
+
+int parse_config(const char * filename)
+{
+	if (filename == nullptr)
+	{
+		return 1;
+	}
+	config["bits"] = 16;
+	config["frequency"] = 38000;
+	config["dutycycle"] = 50;
+	config["header.on"] = 9000;
+	config["header.off"] = 4500;
+	config["one.on"] = 562;
+	config["one.off"] = 1688;
+	config["zero.on"] = 562;
+	config["zero.off"] = 562;
+	config["ptrail"] = 562;
+	config["min_repeat"] = 0;
+	config["gap"] = 108000;
+	config["pre_data_bits"] = 0;
+
+	std::ifstream configfile(filename);
+
+	while (configfile.good()) {
+		std::string line;
+		std::getline(configfile,line);
+		handle_line(line);
+	}
+
+	return 0;
+}
+
+// -p pin
+// -f config
+// * button name(s)
+int main(int argc, char *argv[])
+{
+	const char * configfile = nullptr;
+	int pin = 23;
+	int c ;
+	bool dumpconfig=false;
+	while( ( c = getopt (argc, argv, "dp:f:") ) != -1 ) 
+	{
+		switch(c)
+		{
+			case 'd':
+				dumpconfig = true;
+				break;
+			case 'f':
+				if(optarg) configfile = optarg;
+				break;
+			case 'p':
+				if(optarg) pin = std::atoi(optarg) ;
+				break;
+		}			    
+	}
+	if (parse_config(configfile)) {
+		std::cerr<<"Failed to parse config"<<std::endl;
+		exit(1);
+	}
+
+	if (dumpconfig) {
+		for (auto k:config)
+		{
+			std::cout << "config: "<<k.first<<" "<<k.second<<std::endl;
+		}
+		for (auto k:codes)
+		{
+			std::cout << "code  : "<<k.first<<" "<<k.second<<std::endl;
+		}
+	}
+	int result = -1;
+	transmitWavePre(pin);
+	for (c=optind ; c < argc ; ++c)
+	{
+		std::map<std::string,std::string>::iterator code = codes.find(argv[c]);
+		if (code == codes.end()) {
+			std::cerr << "Button \"" << argv[c] << "\" is unknown." << std::endl;
+			result |= 1;
+			continue;
+		}
+		if (result == -1) { result = 0; }
+
+		std::string pattern("0x");
+		if (config.find("pre_data") != config.end()) {
+			char xx[50];
+			snprintf(xx,sizeof(xx),"%0*x",(3+config["bits"])/4,config["pre_data"]);
+			pattern += xx;
+		}
+		pattern.append(code->second);
+		int gap = config["gap"];
+		if (config.find("repeat_gap") != config.end()) {
+			gap = config["repeat_gap"];
+		}
+		//std::cout << "pattern is "<<pattern<<std::endl;
+		gpioPulse_t irSignal[MAX_PULSES];
+		unsigned int pulseCount = 0;
+		if (irSlingPrepare(irSignal, &pulseCount,
+				pin,
+				config["frequency"],
+				double(config["dutycycle"])/100,
+				config["header.on"],
+				config["header.off"],
+				config["one.on"],
+				config["zero.on"],
+				config["one.off"],
+				config["zero.off"],
+				config["ptrail"],
+				pattern.c_str(),
+				config["bits"] + config["pre_data_bits"])) {
+			std::cerr << "Failed to prepare signal" <<std::endl;
+			continue;
+		}
+
+		for(int i=0 ; i<=config["min_repeat"]; ++i) {
+			transmitWave(irSignal, pulseCount);
+			// only delay if repeating this press
+			if (i < config["min_repeat"]) {
+				usleep(gap);
+			}
+		}
+
+		// only delay if more buttons
+		if (c < (argc-1)) {
+			usleep(config["gap"]);
+		}
+	}
+
+	transmitWavePost();
+	return result;
+}
+

--- a/irsling.cpp
+++ b/irsling.cpp
@@ -8,17 +8,15 @@
 #include <unistd.h>
 #include "irslinger.h"
 
-// TODO
-// support raw
-// support bit counts not %4
-// support multiple concurrent remotes
+// compile with:
+// g++ irsling.cpp -lpigpio -lm -lpthread
 
 // LIRC config not supported:
 // http://www.lirc.org/html/lircd.conf.html
 // include
 // manual_sort
 // suppress_repeat
-// flags RC6 / RC-MM / REVERSE / NO_HEAD_REP / NO_FOOT_REP / CONST_LENGTH / RAW_CODES / REPEAT_HEADER
+// flags RC6 / RC-MM / REVERSE / NO_HEAD_REP / NO_FOOT_REP / CONST_LENGTH / REPEAT_HEADER
 // driver
 // eps
 // aeps
@@ -48,14 +46,26 @@ class remote_config {
 			config["min_repeat"] = 0;
 			config["gap"] = 108000;
 			config["pre_data_bits"] = 0;
+			config["post_data_bits"] = 0;
 		};
+		// config parameters: name -> value
 		std::unordered_map<std::string,int> config;
+		// key codes: button label -> hex code
 		std::unordered_map<std::string,std::string> codes;
+		// other arbitrary flags
 		std::unordered_set<std::string> flags;
+		// raw codes
+		std::unordered_map<std::string, std::vector<int> > rawcodes;
 };
+
+// map of config for each known remote
 std::unordered_map<std::string, remote_config> remotes;
+
+// statefulness while parsing remote
 bool in_codes = false;
 std::string remotename = "default";
+bool in_rawcodes = false;
+std::string buttonname;
 
 
 void tokenise(const std::string in, const char * delimiters, std::vector<std::string> &out)
@@ -80,42 +90,56 @@ int handle_line(const std::string & line)
 	std::vector<std::string> tokens;
 	tokenise(line, space_delimiters, tokens);
 	// bale if no tokens
-	if (tokens.empty()) { return 0; }
-	if (tokens[0].at(0) == '#') { return 0; }
+	if (tokens.empty())
+	{ return 0; }
+	if (tokens[0].at(0) == '#')
+	{ return 0; }
 	// find number of valid tokens
 	size_t i=1;
 	size_t maxtoken = tokens.size()-1;
-	while (i < tokens.size()) {
-		if (tokens[i].at(0) == '#') {
+	while (i < tokens.size())
+	{
+		if (tokens[i].at(0) == '#')
+		{
 			maxtoken = i-1;
 			break;
 		}
 		++i;
 	}
-	// all lines in >=2 tokens
-	if (maxtoken == 0) {
+	// all lines in >=2 tokens unless we are in raw codes
+	if ((maxtoken == 0) && (in_rawcodes == false))
+	{
 		std::cerr << "Invalid line: "<<line<<std::endl;
 		return -1;
 	}
 
 	char xx[50];
 	// special case config
-	if (tokens[0] == "begin" && tokens[1] == "remote") {
+	if (tokens[0] == "begin" && tokens[1] == "remote")
+	{
 		// no action required
 		return 0;
 	}
-	if (tokens[0] == "end" && tokens[1] == "remote") {
+	if (tokens[0] == "end" && tokens[1] == "remote")
+	{
 		// no action required
 		return 0;
 	}
-	if (tokens[0] == "name") {
-		remotename = tokens[1];
+	if (tokens[0] == "name")
+	{
+		if (in_rawcodes)
+		{
+			buttonname = tokens[1];
+		} else {
+			remotename = tokens[1];
+		}
 		return 0;
 	}
 
 	remote_config &remote(remotes[remotename]);
 
-	if (tokens[0] == "flags") {
+	if (tokens[0] == "flags")
+	{
 		std::vector<std::string> fv;
 		tokenise(tokens[1],"| ", fv);
 		// convert to a set for easy reference
@@ -127,8 +151,10 @@ int handle_line(const std::string & line)
 	}
 	try
 	{
-		if (tokens[0] == "header") {
-			if (maxtoken == 1) {
+		if (tokens[0] == "header")
+		{
+			if (maxtoken == 1)
+			{
 				std::cerr << "Missing off time in line: "<<line<<std::endl;
 				return -1;
 			}
@@ -136,8 +162,10 @@ int handle_line(const std::string & line)
 			remote.config["header.off"] = std::stoi(tokens[2]);
 			return 0;
 		}
-		if (tokens[0] == "one") {
-			if (maxtoken == 1) {
+		if (tokens[0] == "one")
+		{
+			if (maxtoken == 1)
+			{
 				std::cerr << "Missing off time in line: "<<line<<std::endl;
 				return -1;
 			}
@@ -145,8 +173,10 @@ int handle_line(const std::string & line)
 			remote.config["one.off"] = std::stoi(tokens[2]);
 			return 0;
 		}
-		if (tokens[0] == "zero") {
-			if (maxtoken == 1) {
+		if (tokens[0] == "zero")
+		{
+			if (maxtoken == 1)
+			{
 				std::cerr << "Missing off time in line: "<<line<<std::endl;
 				return -1;
 			}
@@ -154,8 +184,10 @@ int handle_line(const std::string & line)
 			remote.config["zero.off"] = std::stoi(tokens[2]);
 			return 0;
 		}
-		if (tokens[0] == "repeat") {
-			if (maxtoken == 1) {
+		if (tokens[0] == "repeat")
+		{
+			if (maxtoken == 1)
+			{
 				std::cerr << "Missing off time in line: "<<line<<std::endl;
 				return -1;
 			}
@@ -163,18 +195,42 @@ int handle_line(const std::string & line)
 			remote.config["repeat.off"] = std::stoi(tokens[2]);
 			return 0;
 		}
-		if (tokens[0] == "begin" && tokens[1] == "codes") {
+		if (tokens[0] == "begin" && tokens[1] == "codes")
+		{
 			in_codes = true;
+			in_rawcodes = false;
 			return 0;
 		}
-		if (tokens[0] == "end" && tokens[1] == "codes") {
+		if (tokens[0] == "begin" && tokens[1] == "raw_codes")
+		{
+			in_codes = false;
+			in_rawcodes = true;
+			return 0;
+		}
+		if (tokens[0] == "end" && tokens[1] == "codes")
+		{
 			in_codes = false;
 			return 0;
 		}
-		if (in_codes) {
+		if (tokens[0] == "end" && tokens[1] == "raw_codes")
+		{
+			in_rawcodes = false;
+			return 0;
+		}
+		if (in_rawcodes)
+		{
+			for(auto r:tokens)
+			{
+				remote.rawcodes[buttonname].push_back(std::stoi(r,nullptr,0));
+			}
+			return 0;
+		}
+		if (in_codes)
+		{
 			// TODO what if bits is not multiple of 4?
-			snprintf(xx,sizeof(xx),"%0*x",(3+remote.config["bits"])/4,std::stoi(tokens[1],nullptr,0));
-			remote.codes[tokens[0]] = std::string(xx);
+			//snprintf(xx,sizeof(xx),"%0*x",(3+remote.config["bits"])/4,std::stoi(tokens[1],nullptr,0));
+			//remote.codes[tokens[0]] = std::string(xx);
+			remote.codes[tokens[0]] = tokens[1];
 			return 0;
 		}
 
@@ -198,7 +254,8 @@ int parse_config(const char * filename)
 
 	std::ifstream configfile(filename);
 
-	while (configfile.good()) {
+	while (configfile.good())
+	{
 		std::string line;
 		std::getline(configfile,line);
 		handle_line(line);
@@ -216,7 +273,8 @@ int main(int argc, char *argv[])
 	int pin = 23;
 	int c ;
 	bool dumpconfig=false;
-	std::string thisremote = "";
+	std::string thisremote;
+	std::string defaultremote;
 	while( ( c = getopt (argc, argv, "r:dp:f:") ) != -1 ) 
 	{
 		switch(c)
@@ -225,43 +283,65 @@ int main(int argc, char *argv[])
 				dumpconfig = true;
 				break;
 			case 'f':
-				if(optarg) configfile = optarg;
+				if (parse_config(optarg))
+				{
+					std::cerr<<"Failed to parse config from "<<optarg<<std::endl;
+					exit(1);
+				}
 				break;
 			case 'p':
 				if(optarg) pin = std::atoi(optarg) ;
 				break;
 			case 'r':
-				if(optarg) thisremote = optarg;
+				if(optarg) defaultremote = optarg;
 				break;
+			default:
+				std::cerr<<"Unexpected argument "<<c<<std::endl
+				         <<"Valid arguments are:"<<std::endl
+					 <<"    -p pinnumber"<<std::endl
+					 <<"    -f lircremotefile"<<std::endl
+					 <<"    -r defaultremotename"<<std::endl
+					 <<"    -d = dumpconfig"<<std::endl
+					 <<"     button button button... or"<<std::endl
+					 <<"     remotename.button remotename.button..."<<std::endl;
+				exit(1);
 		}			    
 	}
-	if (parse_config(configfile)) {
-		std::cerr<<"Failed to parse config"<<std::endl;
+	if (remotes.size() == 0)
+	{
+		std::cerr<<"No remotes defined!" << std::endl;
 		exit(1);
 	}
 
 	// if only one remote defined then use that
 	if ((remotes.size() == 1) && (thisremote.size() == 0))
 	{
-		thisremote = remotes.begin()->first;
+		defaultremote = remotes.begin()->first;
 	}
-	if (remotes.find(thisremote) == remotes.end())
-	{
-		std::cerr << "Remote " << thisremote << " does not exist" << std::endl;
-		exit(1);
-	}
-	// TODO move this inside the loop so that can send commands to multiple remotes
-	remote_config &remote(remotes[thisremote]);
 
-	if (dumpconfig) {
-		std::cout <<"Config for remote "<<thisremote<<std::endl;
-		for (auto k:remote.config)
+	if (dumpconfig)
+	{
+		for (auto r:remotes)
 		{
-			std::cout << "config: "<<k.first<<" "<<k.second<<std::endl;
-		}
-		for (auto k:remote.codes)
-		{
-			std::cout << "code  : "<<k.first<<" "<<k.second<<std::endl;
+			remote_config &remote(r.second);
+			std::cout <<"Config for remote "<<r.first<<std::endl;
+			for (auto k:remote.config)
+			{
+				std::cout << "config: "<<k.first<<" "<<k.second<<std::endl;
+			}
+			for (auto k:remote.codes)
+			{
+				std::cout << "code  : "<<k.first<<" "<<k.second<<std::endl;
+			}
+			for (auto k:remote.rawcodes)
+			{
+				std::cout << "raw   : "<<k.first;
+				for (auto l:k.second)
+				{
+					std::cout<<" "<<l;
+				}
+				std::cout<<std::endl;
+			}
 		}
 	}
 
@@ -269,75 +349,201 @@ int main(int argc, char *argv[])
 	transmitWavePre(pin);
 	for (c=optind ; c < argc ; ++c)
 	{
+		// try to break button into remote.button
+		std::string button;
+		char * dot = strchr(argv[c],'.');
+		if (dot == nullptr)
+		{
+			// no remote mentioned
+			thisremote = defaultremote;
+			button = argv[c];
+		}
+		else
+		{
+			thisremote = std::string(argv[c],dot - argv[c]);
+			button = dot+1;
+		}
 
-		std::unordered_map<std::string,std::string>::iterator code = remote.codes.find(argv[c]);
-		if (code == remote.codes.end()) {
-			std::cerr << "Button \"" << argv[c] << "\" is unknown." << std::endl;
-			result |= 1;
-			continue;
+		if (remotes.find(thisremote) == remotes.end())
+		{
+			std::cerr << "Remote " << thisremote << " does not exist" << std::endl;
+			exit(1);
 		}
-		if (result == -1) { result = 0; }
+		remote_config &remote(remotes[thisremote]);
 
-		std::string pattern("0x");
-		if (remote.config.find("pre_data") != remote.config.end()) {
-			char xx[50];
-			snprintf(xx,sizeof(xx),"%0*x",(3+remote.config["bits"])/4,remote.config["pre_data"]);
-			pattern += xx;
-		}
-		pattern.append(code->second);
-		int gap = remote.config["gap"];
-		if (remote.config.find("repeat_gap") != remote.config.end()) {
-			gap = remote.config["repeat_gap"];
-		}
-		//std::cout << "pattern is "<<pattern<<std::endl;
 		gpioPulse_t irSignal[MAX_PULSES];
 		unsigned int pulseCount = 0;
-		if (remote.flags.find("SPACE_ENC") != remote.flags.end())
+
+		if (remote.flags.find("RAW_CODES") != remote.flags.end())
 		{
-			// nec type
-			if (irSlingPrepare(irSignal, &pulseCount,
-					pin,
-					remote.config["frequency"],
-					double(remote.config["dutycycle"])/100,
-					remote.config["header.on"],
-					remote.config["header.off"],
-					remote.config["one.on"],
-					remote.config["zero.on"],
-					remote.config["one.off"],
-					remote.config["zero.off"],
-					remote.config["ptrail"],
-					pattern.c_str(),
-					remote.config["bits"] + remote.config["pre_data_bits"]))
+			std::unordered_map<std::string,std::vector<int>>::iterator raw = remote.rawcodes.find(button);
+			if (raw == remote.rawcodes.end())
 			{
-				std::cerr << "Failed to prepare signal" <<std::endl;
+				std::cerr << "Button \"" << button << "\" is unknown on remote " << thisremote << std::endl;
+				result |= 1;
 				continue;
 			}
-		} else if (remote.flags.find("RC5") != remote.flags.end())
-		{
-			// nec type
-			if (irSlingPrepareRC5(irSignal, &pulseCount,
-					pin,
-					remote.config["frequency"],
-					double(remote.config["dutycycle"])/100,
-					remote.config["one.on"] + remote.config["one.off"],
-					pattern.c_str(),
-					remote.config["bits"] + remote.config["pre_data_bits"]))
+			if (result == -1) { result = 0; }
+			int pulses[raw->second.size()];
+			int j = 0;
+			for (auto r:raw->second)
+			{
+				pulses[j++] = r;
+			}
+			// ensure we always end in an off
+			if ((j % 2) == 1)
+			{
+				pulses[j] = pulses[j-1];
+			}
+			if (irSlingPrepareRaw(irSignal, &pulseCount,
+						pin,
+						remote.config["frequency"],
+						double(remote.config["dutycycle"])/100,
+						pulses,
+						raw->second.size()))
 			{
 				std::cerr << "Failed to prepare signal" <<std::endl;
 				continue;
 			}
 		}
+		else
+		{
+			std::unordered_map<std::string,std::string>::iterator code = remote.codes.find(button);
+			if (code == remote.codes.end())
+			{
+				std::cerr << "Button \"" << button << "\" is unknown on remote " << thisremote << std::endl;
+				result |= 1;
+				continue;
+			}
+			if (result == -1) { result = 0; }
 
-		for(int i=0 ; i<=remote.config["min_repeat"]; ++i) {
+			// nec type
+			if (remote.flags.find("SPACE_ENC") != remote.flags.end())
+			{
+				// insert the header
+				if (irSlingPrepare(irSignal, &pulseCount,
+							pin,
+							remote.config["frequency"],
+							double(remote.config["dutycycle"])/100,
+							remote.config["header.on"],
+							remote.config["header.off"],
+							0, 0, 0, 0, 0, nullptr, 0)) // no more content
+				{
+					std::cerr << "Failed to prepare header" <<std::endl;
+					continue;
+				}
+
+				// insert the pre-data
+				if ((remote.config.find("pre_data") != remote.config.end()) &&
+					(remote.config.find("pre_data_bits") != remote.config.end()))
+				{
+					int pre_len = (3+remote.config["pre_data_bits"])/4;
+					char pre_data_bits[pre_len+4];
+					snprintf(pre_data_bits,pre_len+3,"0x%0*x",pre_len,remote.config["pre_data"]);
+					if (irSlingPrepare(irSignal, &pulseCount,
+								pin,
+								remote.config["frequency"],
+								double(remote.config["dutycycle"])/100,
+								0, 0, // no header
+								remote.config["one.on"],
+								remote.config["zero.on"],
+								remote.config["one.off"],
+								remote.config["zero.off"],
+								0, // no trailer yet
+								pre_data_bits,
+								remote.config["pre_data_bits"]))
+					{
+						std::cerr << "Failed to prepare pre_data" <<std::endl;
+						continue;
+					}
+				}
+				// insert the actual data
+				if (irSlingPrepare(irSignal, &pulseCount,
+							pin,
+							remote.config["frequency"],
+							double(remote.config["dutycycle"])/100,
+							0, 0, /* no header */
+							remote.config["one.on"],
+							remote.config["zero.on"],
+							remote.config["one.off"],
+							remote.config["zero.off"],
+							0, // no trailer
+							code->second.c_str(),
+							remote.config["bits"]))
+				{
+					std::cerr << "Failed to prepare signal" <<std::endl;
+					continue;
+				}
+				// insert any trailer as required
+				// both trailer data and ptrail
+				int post_len = (3+remote.config["post_data_bits"])/4;
+				char post_data_bits[post_len+4];
+				if ((remote.config.find("post_data") != remote.config.end()) && (post_len > 0))
+				{
+					snprintf(post_data_bits,post_len+3,"0x%0*x",post_len,remote.config["post_data"]);
+				}
+				if (irSlingPrepare(irSignal, &pulseCount,
+							pin,
+							remote.config["frequency"],
+							double(remote.config["dutycycle"])/100,
+							0, 0, /* no header */
+							remote.config["one.on"],
+							remote.config["zero.on"],
+							remote.config["one.off"],
+							remote.config["zero.off"],
+							remote.config["ptrail"],
+							post_data_bits,
+							remote.config["post_data_bits"]))
+				{
+					std::cerr << "Failed to prepare post_data" <<std::endl;
+					continue;
+				}
+			}
+			else if (remote.flags.find("RC5") != remote.flags.end())
+			{
+				std::string pattern("0x");
+				if (remote.config.find("pre_data") != remote.config.end())
+				{
+					// TODO support pre_data_bits not modulo 4
+					char xx[50];
+					snprintf(xx,sizeof(xx),"%0*x",(3+remote.config["bits"])/4,remote.config["pre_data"]);
+					pattern += xx;
+				}
+				pattern.append(code->second);
+				//std::cout << "pattern is "<<pattern<<std::endl;
+				if (irSlingPrepareRC5(irSignal, &pulseCount,
+							pin,
+							remote.config["frequency"],
+							double(remote.config["dutycycle"])/100,
+							remote.config["one.on"] + remote.config["one.off"],
+							pattern.c_str(),
+							remote.config["bits"] + remote.config["pre_data_bits"]))
+				{
+					std::cerr << "Failed to prepare signal" <<std::endl;
+					continue;
+				}
+			}
+		}
+
+		int gap = remote.config["gap"];
+		if (remote.config.find("repeat_gap") != remote.config.end())
+		{
+			gap = remote.config["repeat_gap"];
+		}
+
+		for(int i=0 ; i<=remote.config["min_repeat"]; ++i)
+		{
 			transmitWave(irSignal, pulseCount);
 			// only delay if repeating this press
-			if (i < remote.config["min_repeat"]) {
+			if (i < remote.config["min_repeat"])
+			{
 				usleep(gap);
 			}
 		}
 
 		// only delay if more buttons
-		if (c < (argc-1)) {
+		if (c < (argc-1))
+		{
 			usleep(remote.config["gap"]);
 		}
 	}

--- a/irslinger.h
+++ b/irslinger.h
@@ -252,7 +252,7 @@ static inline int irSlingPrepare(gpioPulse_t *irSignal, unsigned int * pulseCoun
 		carrierFrequency(outPin, frequency, dutyCycle, sendTrailingPulse, irSignal, pulseCount);
 	}
 
-	printf("pulse count is %i\n", *pulseCount);
+	//printf("pulse count is %i\n", *pulseCount);
 	// End Generate Code
 	return 0;
 }

--- a/irslinger.h
+++ b/irslinger.h
@@ -115,7 +115,7 @@ static inline int transmitWave(gpioPulse_t *irSignal, unsigned int pulseCount)
 	{
 		int result = gpioWaveTxSend(waveID, PI_WAVE_MODE_ONE_SHOT);
 
-		printf("Result: %i\n", result);
+		//printf("Result: %i\n", result);
 	}
 	else
 	{
@@ -176,7 +176,7 @@ static inline int irSlingPrepareRC5(gpioPulse_t *irSignal,
 		}
 	}
 
-	printf("pulse count is %i\n", *pulseCount);
+	//printf("pulse count is %i\n", *pulseCount);
 	// End Generate Code
 }
 


### PR DESCRIPTION
I added a program irsling.cpp that uses irslinger.h to transmit codes loaded from a lirc remote control config file.  I've only tested it with an NEC remote and a raw remote but believe it should work with RC5 too. (Apologies for using c++ but there were so many things which would have been a PITA in c but easy in c++).

g++ -o irsling irsling.cpp -lpigpio -lm -lpthread
sudo ./irsling -p pinnumber -f lircconfigfile buttonname buttonname buttonname ...

It can load multiple remotes and you can combine transmissions to >1 remote:

sudo ./irsling -p pinnumber -f lircconfigfile -f lircconfigfile remotename.buttonname remotename.buttonname remotename.buttonname ...

To make this work I had to break the existing transmission functions down in to distinct components but have kept the existing APIs unchanged, with the exception that you can now also pass a hex string e.g. 0x1ee1f30c instead of a binary string for the codes.

I also fixed a couple of type mismatches which caused compile failures with c++.